### PR TITLE
[update]DeckManager.cs、HandAM.cs、BattleM.csの変更

### DIFF
--- a/Assets/Resources/Prefab/CardPrefab.prefab
+++ b/Assets/Resources/Prefab/CardPrefab.prefab
@@ -34,7 +34,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 24, y: -28}
+  m_AnchoredPosition: {x: 24.5, y: -35}
   m_SizeDelta: {x: 125, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6058693015407495428
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Cost : 5'
+  m_text: Mana Text
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 5a10c43262db04caba416c6b0bd78962, type: 2}
   m_sharedMaterial: {fileID: -2269777868690256331, guid: 5a10c43262db04caba416c6b0bd78962, type: 2}
@@ -74,8 +74,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+    rgba: 4281270486
+  m_fontColor: {r: 0.8396226, g: 0, b: 0.18367986, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -201,7 +201,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\u4F53\u5F53\u305F\u308A"
+  m_text: CardNameText
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 5a10c43262db04caba416c6b0bd78962, type: 2}
   m_sharedMaterial: {fileID: -2269777868690256331, guid: 5a10c43262db04caba416c6b0bd78962, type: 2}
@@ -210,8 +210,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+    rgba: 4278255370
+  m_fontColor: {r: 0.03964877, g: 1, b: 0, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -412,7 +412,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Att : 10'
+  m_text: Power Text
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 5a10c43262db04caba416c6b0bd78962, type: 2}
   m_sharedMaterial: {fileID: -2269777868690256331, guid: 5a10c43262db04caba416c6b0bd78962, type: 2}

--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -250,83 +250,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   initialHandSize: 5
---- !u!1 &834353700
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 834353701}
-  - component: {fileID: 834353703}
-  - component: {fileID: 834353702}
-  m_Layer: 5
-  m_Name: HandArea
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &834353701
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 834353700}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1388838492}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.70772046, y: 0.5}
-  m_AnchoredPosition: {x: 120, y: -140}
-  m_SizeDelta: {x: 0, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &834353702
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 834353700}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalFit: 2
-  m_VerticalFit: 0
---- !u!114 &834353703
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 834353700}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: 20
-  m_ChildForceExpandWidth: 0
-  m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!1 &847113310
 GameObject:
   m_ObjectHideFlags: 0
@@ -666,6 +589,99 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1343168817}
   m_CullTransparentMesh: 1
+--- !u!1 &1381604159
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1381604160}
+  - component: {fileID: 1381604163}
+  - component: {fileID: 1381604162}
+  - component: {fileID: 1381604161}
+  m_Layer: 5
+  m_Name: HandArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1381604160
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1381604159}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1388838492}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.105000004, y: 0.049316503}
+  m_AnchorMax: {x: 0.89250004, y: 0.3676835}
+  m_AnchoredPosition: {x: -17, y: 3}
+  m_SizeDelta: {x: 0, y: -49}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1381604161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1381604159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
+--- !u!114 &1381604162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1381604159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 20
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &1381604163
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1381604159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eb87a7b5392464d178f4d12866b62848, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  deckManager: {fileID: 667891639}
+  cardPrefab: {fileID: 8864314493981532776, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
+  handArea: {fileID: 1381604160}
 --- !u!1 &1388838488
 GameObject:
   m_ObjectHideFlags: 0
@@ -762,8 +778,7 @@ RectTransform:
   m_Children:
   - {fileID: 1303532522}
   - {fileID: 1759214110}
-  - {fileID: 834353701}
-  - {fileID: 1933616545}
+  - {fileID: 1381604160}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -780,7 +795,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1401231231}
-  - component: {fileID: 1401231230}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -788,25 +802,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1401231230
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1401231229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 119173f11e6944a18a97b753e7eac3ad, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  deckManager: {fileID: 0}
-  manaManager: {fileID: 0}
-  playerHP: 100
-  enemyHP: 50
-  playerHPText: {fileID: 0}
-  enemyHPText: {fileID: 0}
-  logText: {fileID: 0}
 --- !u!4 &1401231231
 Transform:
   m_ObjectHideFlags: 0
@@ -1116,108 +1111,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1759214109}
   m_CullTransparentMesh: 1
---- !u!1001 &1933616544
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1388838492}
-    m_Modifications:
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 120
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -215
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -150
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8864314493981532776, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-      propertyPath: m_Name
-      value: CardPrefab
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
---- !u!224 &1933616545 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5386021027682884335, guid: 64a0be53733a04d3d9dc4247d1d05bef, type: 3}
-  m_PrefabInstance: {fileID: 1933616544}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2045534209
 GameObject:
   m_ObjectHideFlags: 0
@@ -1302,6 +1195,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2054367236}
+  - component: {fileID: 2054367237}
   m_Layer: 0
   m_Name: BattleManager
   m_TagString: Untagged
@@ -1324,6 +1218,27 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1401231231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2054367237
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2054367235}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 119173f11e6944a18a97b753e7eac3ad, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  deckManager: {fileID: 667891639}
+  manaManager: {fileID: 93932253}
+  handAreaManager: {fileID: 1381604163}
+  defaultCardSprite: {fileID: 4755728945844721729, guid: 3a36a0ce6b0fe4d90a070ac2de83f667, type: 3}
+  playerHP: 30
+  enemyHP: 30
+  playerHPText: {fileID: 0}
+  enemyHPText: {fileID: 0}
+  logText: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BattleScene/BattleManager.cs
+++ b/Assets/Scripts/BattleScene/BattleManager.cs
@@ -6,13 +6,16 @@ public class BattleManager : MonoBehaviour
     [Header("Managers")]
     [SerializeField] private DeckManager deckManager;
     [SerializeField] private ManaManager manaManager;
+    [SerializeField] private HandAreaManager handAreaManager; // HandAreaManagerの参照
+    [SerializeField] private Sprite defaultCardSprite; // カード画像
+
 
     [Header("Player & Enemy HP")]
     [SerializeField] private int playerHP = 30;
     [SerializeField] private int enemyHP = 30;
     [SerializeField] private TMP_Text playerHPText;
     [SerializeField] private TMP_Text enemyHPText;
-    [SerializeField] private HandAreaManager handAreaManager; // HandAreaManagerの参照
+    
 
 
     [Header("UI")]
@@ -20,12 +23,33 @@ public class BattleManager : MonoBehaviour
 
     private bool playerTurn = true;
 
+    // Awake()は、今のところカードUI表示のために設定してある(おそらく後に消す)
+    void Awake()
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            CardData cardData = ScriptableObject.CreateInstance<CardData>();
+            cardData.cardName = "攻撃カード";
+            cardData.manaCost = 2;
+            cardData.cardType = CardType.Attack;
+            cardData.power = 5;
+             cardData.cardImage = defaultCardSprite;
+
+            deckManager.AddCardToDeck(new Card(cardData));
+        }
+
+        deckManager.ShuffleDeck();
+    }
+    
     void Start()
     {
         // ゲーム開始時の手札5枚ドロー
         deckManager.DrawInitialHand();
 
+        // handAreaManager.UpdateHandUI();
+
         UpdateHPUI();
+
         Log("バトル開始！");
 
         // 1ターン目開始

--- a/Assets/Scripts/BattleScene/Card.cs
+++ b/Assets/Scripts/BattleScene/Card.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 public class Card
 {
     private CardData data;       // 元データへの参照
@@ -16,6 +18,6 @@ public class Card
     public Sprite GetSprite() => data.cardImage;
     public CardType GetCardType() => data.cardType;
     public string GetDescription() => data.description;
-    
+
 
 }

--- a/Assets/Scripts/BattleScene/DeckManager.cs
+++ b/Assets/Scripts/BattleScene/DeckManager.cs
@@ -12,6 +12,14 @@ public class DeckManager : MonoBehaviour
     [SerializeField] private int initialHandSize = 5; // ゲーム開始時の手札枚数
 
     /// <summary>
+    /// デッキにカードを追加（初期設定用）
+    /// </summary>
+    public void AddCardToDeck(Card card)
+    {
+        deck.Add(card);
+    }
+
+    /// <summary>
     /// ゲーム開始時に初期手札を引くためのメソッド
     /// </summary>
     public void DrawInitialHand()

--- a/Assets/Scripts/BattleScene/HandAreaManager.cs
+++ b/Assets/Scripts/BattleScene/HandAreaManager.cs
@@ -34,11 +34,11 @@ public class HandAreaManager : MonoBehaviour
 
             // マナコスト
             TMP_Text manaText = cardObj.transform.Find("ManaCostText")?.GetComponent<TMP_Text>();
-            if (manaText) manaText.text = cardData.GetManaCost().ToString();
+            if (manaText) manaText.text = "Cost：" + cardData.GetManaCost().ToString();
 
             // 攻撃力
             TMP_Text powerText = cardObj.transform.Find("PowerText")?.GetComponent<TMP_Text>();
-            if (powerText) powerText.text = cardData.GetPower().ToString();
+            if (powerText) powerText.text = "Att" + cardData.GetPower().ToString();
 
             // 画像
             Image cardImage = cardObj.transform.Find("CardImage")?.GetComponent<Image>();


### PR DESCRIPTION
DeckManager.csの17~20行目に、デッキにカードを追加するメソッドAddCardToDeck(カードUIを表示するテスト用)を追加。(多分完成時には消えてる)
BattleManager.csに、カードUI表示テスト用のAwake()関数を追加(27~39)。また、10行目にSprite型の変数defaultCardSpriteを追加。これも、UI表示するために画像をアタッチする際に使うので、テスト用のもの。
HandAreaManager.csの37行目、41行目を変更。"Cost：" + cardData.GetManaCost().ToString();とすることで、マナコストをUI表示する際に、「Cost : 5」といった具合になるようにするため(37行目)。41行目も同様の理由。