### PR TITLE
[add]cardUI_DragDrop.csの作成 [update]HandAreaManager.csの修正

### DIFF
--- a/Assets/Resources/Prefab/CardPrefab.prefab
+++ b/Assets/Resources/Prefab/CardPrefab.prefab
@@ -495,6 +495,7 @@ GameObject:
   - component: {fileID: 4789475206110074519}
   - component: {fileID: 4419237792540703228}
   - component: {fileID: -8423389002104485498}
+  - component: {fileID: -6895447481850208659}
   m_Layer: 5
   m_Name: CardPrefab
   m_TagString: Untagged
@@ -607,3 +608,19 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &-6895447481850208659
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8864314493981532776}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 341d9df2715a6404eadb07010ab35cc1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nameText: {fileID: 0}
+  manaText: {fileID: 0}
+  powerText: {fileID: 0}
+  cardImage: {fileID: 0}

--- a/Assets/Scripts/BattleScene/CardUI_DragDrop.cs
+++ b/Assets/Scripts/BattleScene/CardUI_DragDrop.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using UnityEngine.EventSystems;
+
+public class CardUI_DragDrop : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+{
+
+    private Card cardData;
+    private BattleManager battleManager;
+    private Transform originalParent;
+    private Vector3 originalPosition;
+    private Canvas canvas;  // ドラッグ時にUIが隠れないようにする
+
+    public void Setup(Card card, BattleManager manager)
+    {
+        cardData = card;
+        battleManager = manager;
+        canvas = GetComponentInParent<Canvas>();
+    }
+
+    // ドラッグ開始
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        originalParent = transform.parent;
+        originalPosition = transform.position;
+        transform.SetParent(canvas.transform); // UIが最前面になるように
+    }
+
+    // ドラッグ中
+    public void OnDrag(PointerEventData eventData)
+    {
+        transform.position = eventData.position;
+    }
+
+    // ドラッグ終了
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        // 仮に画面中央より上でドロップしたらカードをプレイする
+        if (eventData.position.y > Screen.height / 2f)
+        {
+            if (battleManager != null)
+            {
+                battleManager.PlayCard(cardData);
+            }
+            Destroy(gameObject); // カードをUIから削除
+        }
+        else
+        {
+            // 元の位置に戻す
+            transform.SetParent(originalParent);
+            transform.position = originalPosition;
+        }
+    }
+}

--- a/Assets/Scripts/BattleScene/CardUI_DragDrop.cs.meta
+++ b/Assets/Scripts/BattleScene/CardUI_DragDrop.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 341d9df2715a6404eadb07010ab35cc1

--- a/Assets/Scripts/BattleScene/HandAreaManager.cs
+++ b/Assets/Scripts/BattleScene/HandAreaManager.cs
@@ -9,6 +9,7 @@ public class HandAreaManager : MonoBehaviour
     [SerializeField] private DeckManager deckManager;
     [SerializeField] private GameObject cardPrefab;
     [SerializeField] private Transform handArea;
+    [SerializeField] private BattleManager battleManager; // カードプレイ処理に必要
 
     private readonly List<GameObject> spawnedCards = new List<GameObject>();
 
@@ -43,6 +44,13 @@ public class HandAreaManager : MonoBehaviour
             // 画像
             Image cardImage = cardObj.transform.Find("CardImage")?.GetComponent<Image>();
             if (cardImage) cardImage.sprite = cardData.GetSprite();
+
+            // CardUI_DragDropをセットアップ
+            var dragDrop = cardObj.GetComponent<CardUI_DragDrop>();
+            if (dragDrop != null)
+            {
+                dragDrop.Setup(cardData, battleManager);
+            }
 
             spawnedCards.Add(cardObj);
         }


### PR DESCRIPTION
cardUI_DragDropは、カードをドラッグ、ドロップした時のカードのUI表示の処理を担うスクリプト。プレハブのcardPrefabにアタッチしている。
また、HandAreaManager.csにcardUI_DragDropのセットアップメソッドSetup()を呼び出すために、当該スクリプトを修正。HandAreaManager.csによって作成されたカード1枚1枚に対して、ドラッグドロップが可能に。
なお、現状ではゲームプレイ画面の中央より上にドロップした場合は、カードが削除され、下にドロップした場合は、ドラッグ前の元の位置にカードが戻る。